### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity that was announced by the principal.

## Changes Made
- Added "GitHub Skills" to the activities list in `src/app.py`
- Description highlights practical coding and collaboration skills
- Mentions GitHub Certifications program for college applications
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Capacity: 25 students
- Currently accepting registrations (no participants yet)

## Resolves
Closes #6

## Testing
- The activity should now appear in the activities list on the website
- Students should be able to sign up for the activity
- Activity details should display correctly with description and schedule